### PR TITLE
(#101)  avoid injecting imageloader via viewmodel

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,40 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <JavaCodeStyleSettings>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="false" module="true" />
+          <package name="android" withSubpackages="true" static="true" />
+          <package name="androidx" withSubpackages="true" static="true" />
+          <package name="com" withSubpackages="true" static="true" />
+          <package name="junit" withSubpackages="true" static="true" />
+          <package name="net" withSubpackages="true" static="true" />
+          <package name="org" withSubpackages="true" static="true" />
+          <package name="java" withSubpackages="true" static="true" />
+          <package name="javax" withSubpackages="true" static="true" />
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="android" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="androidx" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="com" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="junit" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="net" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="org" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="javax" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -3,7 +3,6 @@
   <component name="CompilerConfiguration">
     <bytecodeTargetLevel target="17">
       <module name="DAZN_Code_Challenge.baselineprofile" target="21" />
-      <module name="Video_Player_App.baselineprofile" target="21" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-07-05T23:48:56.537938Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=276a64acda217ece" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -227,7 +227,7 @@ dependencies {
 
     // Glide for Images
     implementation(libs.coil)
-    implementation(libs.coil.network.ktor3)
+    implementation(libs.coil.network.okhttp)
     implementation(libs.coil.gif)
     implementation(libs.coil.test)
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -227,7 +227,9 @@ dependencies {
 
     // Glide for Images
     implementation(libs.coil)
+    implementation(libs.coil.network.ktor3)
     implementation(libs.coil.gif)
+    implementation(libs.coil.test)
 
     // Retrofit 2
     implementation(libs.retrofit)

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/MainActivity.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/MainActivity.kt
@@ -26,16 +26,20 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.navigation.compose.rememberNavController
+import coil3.ImageLoader
 import com.rwmobi.dazncodechallenge.ui.components.DAZNCodeChallengeApp
 import com.rwmobi.dazncodechallenge.ui.theme.DAZNCodeChallengeTheme
 import com.rwmobi.dazncodechallenge.ui.utils.hasPictureInPicturePermission
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
+import javax.inject.Inject
 
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
+    @Inject
+    lateinit var imageLoader: ImageLoader
     private var isInPipMode by mutableStateOf(isInPictureInPictureMode)
     private var isPipModeSupported by mutableStateOf(false)
 
@@ -55,6 +59,7 @@ class MainActivity : ComponentActivity() {
                         .imePadding()
                         .safeDrawingPadding(),
                     windowSizeClass = calculateWindowSizeClass(this),
+                    imageLoader = imageLoader,
                     isPipModeSupported = isPipModeSupported,
                     isInPictureInPictureMode = isInPipMode,
                     navController = navController,

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/di/CoilModule.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/di/CoilModule.kt
@@ -8,9 +8,7 @@
 package com.rwmobi.dazncodechallenge.di
 
 import android.content.Context
-import coil.ImageLoader
-import coil.decode.GifDecoder
-import coil.decode.ImageDecoderDecoder
+import coil3.ImageLoader
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -24,14 +22,8 @@ object CoilModule {
     @Singleton
     @Provides
     fun provideCoilImageLoader(@ApplicationContext context: Context): ImageLoader {
-        return ImageLoader.Builder(context)
-            .components {
-                if (android.os.Build.VERSION.SDK_INT >= 28) {
-                    add(ImageDecoderDecoder.Factory())
-                } else {
-                    add(GifDecoder.Factory())
-                }
-            }
+        return ImageLoader
+            .Builder(context)
             .build()
     }
 }

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/components/DAZNCodeChallengeApp.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/components/DAZNCodeChallengeApp.kt
@@ -34,11 +34,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewScreenSizes
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import coil3.ImageLoader
 import com.rwmobi.dazncodechallenge.ui.navigation.AppNavHost
 import com.rwmobi.dazncodechallenge.ui.navigation.AppNavItem
 import com.rwmobi.dazncodechallenge.ui.theme.DAZNCodeChallengeTheme
@@ -75,6 +77,7 @@ fun DAZNCodeChallengeApp(
     isInPictureInPictureMode: Boolean,
     isPipModeSupported: Boolean,
     windowSizeClass: WindowSizeClass,
+    imageLoader: ImageLoader,
     navController: NavHostController,
     snackbarHostState: SnackbarHostState,
 ) {
@@ -139,6 +142,7 @@ fun DAZNCodeChallengeApp(
                     .fillMaxSize()
                     .padding(paddingValues),
                 navController = navController,
+                imageLoader = imageLoader,
                 lastDoubleTappedNavItem = lastDoubleTappedNavItem.value,
                 isInPictureInPictureMode = isInPictureInPictureMode,
                 isPipModeSupported = isPipModeSupported,
@@ -171,6 +175,7 @@ private fun Preview() {
                 isInPictureInPictureMode = false,
                 isPipModeSupported = false,
                 windowSizeClass = getPreviewWindowSizeClass(),
+                imageLoader = ImageLoader(LocalContext.current),
                 navController = rememberNavController(),
                 snackbarHostState = remember { SnackbarHostState() },
             )

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/components/EventListItem.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/components/EventListItem.kt
@@ -31,9 +31,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import coil.ImageLoader
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil3.ImageLoader
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.rwmobi.dazncodechallenge.domain.model.Event
 import com.rwmobi.dazncodechallenge.ui.previewparameter.EventProvider
 import com.rwmobi.dazncodechallenge.ui.theme.DAZNCodeChallengeTheme

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/components/ScheduleListItem.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/components/ScheduleListItem.kt
@@ -30,9 +30,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import coil.ImageLoader
-import coil.compose.AsyncImage
-import coil.request.ImageRequest
+import coil3.ImageLoader
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
 import com.rwmobi.dazncodechallenge.domain.model.Schedule
 import com.rwmobi.dazncodechallenge.ui.previewparameter.ScheduleProvider
 import com.rwmobi.dazncodechallenge.ui.theme.DAZNCodeChallengeTheme

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsList.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsList.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import coil.ImageLoader
+import coil3.ImageLoader
 import com.rwmobi.dazncodechallenge.R
 import com.rwmobi.dazncodechallenge.domain.model.Event
 import com.rwmobi.dazncodechallenge.ui.components.EventListItem

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsScreen.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import coil.ImageLoader
+import coil3.ImageLoader
 import com.rwmobi.dazncodechallenge.R
 import com.rwmobi.dazncodechallenge.ui.components.NoDataScreen
 

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsViewModel.kt
@@ -5,14 +5,12 @@
  *
  */
 
-package com.rwmobi.dazncodechallenge.ui.viewmodel
+package com.rwmobi.dazncodechallenge.ui.destinations.events
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import coil.ImageLoader
 import com.rwmobi.dazncodechallenge.di.DispatcherModule
 import com.rwmobi.dazncodechallenge.domain.repository.Repository
-import com.rwmobi.dazncodechallenge.ui.destinations.schedule.ScheduleUIState
 import com.rwmobi.dazncodechallenge.ui.model.ErrorMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
@@ -25,12 +23,12 @@ import java.util.UUID
 import javax.inject.Inject
 
 @HiltViewModel
-class ScheduleViewModel @Inject constructor(
+class EventsViewModel @Inject constructor(
     private val repository: Repository,
-    private val imageLoader: ImageLoader,
     @DispatcherModule.IoDispatcher private val dispatcher: CoroutineDispatcher,
 ) : ViewModel() {
-    private val _uiState: MutableStateFlow<ScheduleUIState> = MutableStateFlow(ScheduleUIState(isLoading = true))
+    private val _uiState: MutableStateFlow<EventsUIState> =
+        MutableStateFlow(EventsUIState(isLoading = true))
     val uiState = _uiState.asStateFlow()
 
     fun errorShown(errorId: Long) {
@@ -48,12 +46,10 @@ class ScheduleViewModel @Inject constructor(
         }
     }
 
-    fun getImageLoader() = imageLoader
-
     fun fetchCacheAndRefresh() {
         startLoading()
         viewModelScope.launch(dispatcher) {
-            val isSuccess = getSchedule(setLoadingCompleted = false)
+            val isSuccess = getEvents(setLoadingCompleted = false)
             if (isSuccess) {
                 refresh()
             }
@@ -64,27 +60,27 @@ class ScheduleViewModel @Inject constructor(
         startLoading()
 
         viewModelScope.launch(dispatcher) {
-            val refreshResult = repository.refreshSchedule()
+            val refreshResult = repository.refreshEvents()
             refreshResult.fold(
                 onSuccess = {
-                    getSchedule()
+                    getEvents()
                 },
                 onFailure = { exception ->
-                    Timber.tag("refresh").e(exception)
+                    Timber.Forest.tag("refresh").e(exception)
                     updateUIForError(exception.message ?: "Unknown network communication error")
                 },
             )
         }
     }
 
-    private suspend fun getSchedule(setLoadingCompleted: Boolean = true): Boolean {
-        val getScheduleResult = repository.getSchedule()
-        return getScheduleResult.fold(
-            onSuccess = { schedules ->
+    private suspend fun getEvents(setLoadingCompleted: Boolean = true): Boolean {
+        val getEventsResult = repository.getEvents()
+        return getEventsResult.fold(
+            onSuccess = { events ->
                 _uiState.update { currentUiState ->
                     currentUiState.copy(
                         isLoading = !setLoadingCompleted,
-                        schedules = schedules,
+                        events = events,
                     )
                 }
                 true

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerViewModel.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerViewModel.kt
@@ -5,7 +5,7 @@
  *
  */
 
-package com.rwmobi.dazncodechallenge.ui.viewmodel
+package com.rwmobi.dazncodechallenge.ui.destinations.exoplayer
 
 import androidx.annotation.OptIn
 import androidx.lifecycle.ViewModel
@@ -15,7 +15,6 @@ import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.HttpDataSource
-import com.rwmobi.dazncodechallenge.ui.destinations.exoplayer.ExoPlayerUIState
 import com.rwmobi.dazncodechallenge.ui.model.ErrorMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -23,6 +22,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import java.util.UUID
 import javax.inject.Inject
+import kotlin.collections.plus
 
 @HiltViewModel
 @OptIn(UnstableApi::class)

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/schedule/ScheduleScreen.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/schedule/ScheduleScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import coil.ImageLoader
+import coil3.ImageLoader
 import com.rwmobi.dazncodechallenge.R
 import com.rwmobi.dazncodechallenge.ui.components.NoDataScreen
 import kotlinx.coroutines.delay

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/schedule/SchedulesList.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/schedule/SchedulesList.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import coil.ImageLoader
+import coil3.ImageLoader
 import com.rwmobi.dazncodechallenge.R
 import com.rwmobi.dazncodechallenge.domain.model.Schedule
 import com.rwmobi.dazncodechallenge.ui.components.ScheduleListItem

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/navigation/AppNavHost.kt
@@ -23,18 +23,19 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import coil3.ImageLoader
 import com.rwmobi.dazncodechallenge.ui.destinations.events.EventsScreen
 import com.rwmobi.dazncodechallenge.ui.destinations.events.EventsUIEvent
+import com.rwmobi.dazncodechallenge.ui.destinations.events.EventsViewModel
 import com.rwmobi.dazncodechallenge.ui.destinations.exoplayer.ExoPlayerScreen
 import com.rwmobi.dazncodechallenge.ui.destinations.exoplayer.ExoPlayerUIEvent
+import com.rwmobi.dazncodechallenge.ui.destinations.exoplayer.ExoPlayerViewModel
 import com.rwmobi.dazncodechallenge.ui.destinations.schedule.ScheduleScreen
 import com.rwmobi.dazncodechallenge.ui.destinations.schedule.ScheduleUIEvent
+import com.rwmobi.dazncodechallenge.ui.destinations.schedule.ScheduleViewModel
 import com.rwmobi.dazncodechallenge.ui.theme.dazn_background
 import com.rwmobi.dazncodechallenge.ui.theme.dazn_surface
 import com.rwmobi.dazncodechallenge.ui.utils.enterPIPMode
-import com.rwmobi.dazncodechallenge.ui.viewmodel.EventsViewModel
-import com.rwmobi.dazncodechallenge.ui.viewmodel.ExoPlayerViewModel
-import com.rwmobi.dazncodechallenge.ui.viewmodel.ScheduleViewModel
 
 @Composable
 fun AppNavHost(
@@ -43,6 +44,7 @@ fun AppNavHost(
     isInPictureInPictureMode: Boolean,
     isPipModeSupported: Boolean,
     lastDoubleTappedNavItem: AppNavItem?,
+    imageLoader: ImageLoader,
     onShowSnackbar: suspend (String) -> Unit,
     onScrolledToTop: (AppNavItem) -> Unit,
 ) {
@@ -64,7 +66,7 @@ fun AppNavHost(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(color = dazn_surface),
-                imageLoader = viewModel.getImageLoader(),
+                imageLoader = imageLoader,
                 uiState = uiState,
                 uiEvent = EventsUIEvent(
                     onInitialLoad = { viewModel.fetchCacheAndRefresh() },
@@ -93,7 +95,7 @@ fun AppNavHost(
                 modifier = Modifier
                     .fillMaxSize()
                     .background(color = dazn_surface),
-                imageLoader = viewModel.getImageLoader(),
+                imageLoader = imageLoader,
                 uiState = uiState,
                 uiEvent = ScheduleUIEvent(
                     onInitialLoad = { viewModel.fetchCacheAndRefresh() },

--- a/app/src/test/java/com/rwmobi/dazncodechallenge/data/source/local/RoomDbDataSourceTest.kt
+++ b/app/src/test/java/com/rwmobi/dazncodechallenge/data/source/local/RoomDbDataSourceTest.kt
@@ -27,10 +27,12 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import kotlin.test.assertContentEquals
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
+@Config(sdk = [35])
 @RunWith(RobolectricTestRunner::class)
 internal class RoomDbDataSourceTest {
 

--- a/app/src/test/java/com/rwmobi/dazncodechallenge/data/source/local/dao/EventDaoTest.kt
+++ b/app/src/test/java/com/rwmobi/dazncodechallenge/data/source/local/dao/EventDaoTest.kt
@@ -22,6 +22,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -29,6 +30,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
+@Config(sdk = [35])
 @RunWith(RobolectricTestRunner::class)
 internal class EventDaoTest {
 

--- a/app/src/test/java/com/rwmobi/dazncodechallenge/data/source/local/dao/ScheduleDaoTest.kt
+++ b/app/src/test/java/com/rwmobi/dazncodechallenge/data/source/local/dao/ScheduleDaoTest.kt
@@ -22,6 +22,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -29,6 +30,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
+@Config(sdk = [35])
 @RunWith(RobolectricTestRunner::class)
 internal class ScheduleDaoTest {
 

--- a/app/src/test/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/dazncodechallenge/ui/destinations/events/EventsViewModelTest.kt
@@ -5,14 +5,10 @@
  *
  */
 
-package com.rwmobi.dazncodechallenge.ui.viewmodel
+package com.rwmobi.dazncodechallenge.ui.destinations.events
 
-import coil.ImageLoader
 import com.rwmobi.dazncodechallenge.data.repository.FakeRepository
-import com.rwmobi.dazncodechallenge.test.EventSampleData.event1
-import com.rwmobi.dazncodechallenge.test.EventSampleData.event2
-import com.rwmobi.dazncodechallenge.test.EventSampleData.event3
-import io.mockk.mockk
+import com.rwmobi.dazncodechallenge.test.EventSampleData
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Before
@@ -21,13 +17,11 @@ import java.io.IOException
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
-import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 internal class EventsViewModelTest {
     private lateinit var fakeRepository: FakeRepository
-    private lateinit var mockImageLoader: ImageLoader
 
     // Subject under test
     private lateinit var viewModel: EventsViewModel
@@ -35,10 +29,8 @@ internal class EventsViewModelTest {
     @Before
     fun init() {
         fakeRepository = FakeRepository()
-        mockImageLoader = mockk(relaxed = true)
         viewModel = EventsViewModel(
             repository = fakeRepository,
-            imageLoader = mockImageLoader,
             dispatcher = UnconfinedTestDispatcher(),
         )
     }
@@ -49,14 +41,14 @@ internal class EventsViewModelTest {
     fun `displays refreshed events when fetchCacheAndRefresh is successful`() {
         // GIVEN: The repository returns remote events (event1, event2) and local events (event3)
         // WHEN: fetchCacheAndRefresh is called
-        fakeRepository.setRemoteEventsForTest(listOf(event1, event2))
-        fakeRepository.setLocalEventsForTest(listOf(event3))
+        fakeRepository.setRemoteEventsForTest(listOf(EventSampleData.event1, EventSampleData.event2))
+        fakeRepository.setLocalEventsForTest(listOf(EventSampleData.event3))
 
         viewModel.fetchCacheAndRefresh()
 
         val uiState = viewModel.uiState.value
         assertFalse(uiState.isLoading)
-        assertEquals(listOf(event1, event2), uiState.events)
+        assertEquals(listOf(EventSampleData.event1, EventSampleData.event2), uiState.events)
     }
 
     @Test
@@ -65,7 +57,7 @@ internal class EventsViewModelTest {
         // WHEN: fetchCacheAndRefresh is called
         val exceptionMessage = "repository error"
         fakeRepository.setExceptionForTest(IOException(exceptionMessage))
-        fakeRepository.setRemoteEventsForTest(listOf(event1, event2))
+        fakeRepository.setRemoteEventsForTest(listOf(EventSampleData.event1, EventSampleData.event2))
 
         viewModel.fetchCacheAndRefresh()
 
@@ -80,22 +72,22 @@ internal class EventsViewModelTest {
     fun `updates events successfully when refresh is called`() {
         // GIVEN: The repository returns remote events (event1, event2) and local events (event3)
         // WHEN: refresh is called after initial fetch
-        fakeRepository.setRemoteEventsForTest(listOf(event1, event2))
-        fakeRepository.setLocalEventsForTest(listOf(event3))
+        fakeRepository.setRemoteEventsForTest(listOf(EventSampleData.event1, EventSampleData.event2))
+        fakeRepository.setLocalEventsForTest(listOf(EventSampleData.event3))
         viewModel.fetchCacheAndRefresh()
 
         viewModel.refresh()
 
         val uiState = viewModel.uiState.value
         assertFalse(uiState.isLoading)
-        assertEquals(listOf(event1, event2), uiState.events)
+        assertEquals(listOf(EventSampleData.event1, EventSampleData.event2), uiState.events)
     }
 
     @Test
     fun `retains cached events and shows error when refresh fails`() {
         // GIVEN: Initial data fetch and an error set for the repository
         // WHEN: refresh is called
-        fakeRepository.setRemoteEventsForTest(listOf(event3))
+        fakeRepository.setRemoteEventsForTest(listOf(EventSampleData.event3))
         viewModel.fetchCacheAndRefresh()
 
         val exceptionMessage = "repository error"
@@ -104,7 +96,7 @@ internal class EventsViewModelTest {
 
         val uiState = viewModel.uiState.value
         assertFalse(uiState.isLoading)
-        assertEquals(listOf(event3), uiState.events)
+        assertEquals(listOf(EventSampleData.event3), uiState.events)
         assertEquals(1, uiState.errorMessages.size)
         assertEquals(exceptionMessage, uiState.errorMessages[0].message)
     }
@@ -186,15 +178,5 @@ internal class EventsViewModelTest {
 
         val uiState = viewModel.uiState.value
         assertEquals(expectedRequestScrollToTop, uiState.requestScrollToTop)
-    }
-
-    @Test
-    fun `returns correct image loader instance`() {
-        // GIVEN: Any initial state
-        // WHEN: getImageLoader is called
-        viewModel.fetchCacheAndRefresh()
-        val imageLoader = viewModel.getImageLoader()
-        val expectedImageLoader = mockImageLoader
-        assertSame(expectedImageLoader, imageLoader)
     }
 }

--- a/app/src/test/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerViewModelTest.kt
@@ -5,7 +5,7 @@
  *
  */
 
-package com.rwmobi.dazncodechallenge.ui.viewmodel
+package com.rwmobi.dazncodechallenge.ui.destinations.exoplayer
 
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
@@ -23,12 +23,14 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
+@Config(sdk = [35])
 @RunWith(RobolectricTestRunner::class)
 internal class ExoPlayerViewModelTest {
     private lateinit var mockPlayer: Player
@@ -67,7 +69,12 @@ internal class ExoPlayerViewModelTest {
         val expectedVideoWidth = 640
         val expectedVideoHeight = 1080
         every { mockPlayer.play() } answers {
-            listenerSlot.captured.onVideoSizeChanged(VideoSize(expectedVideoWidth, expectedVideoHeight))
+            listenerSlot.captured.onVideoSizeChanged(
+                VideoSize(
+                    expectedVideoWidth,
+                    expectedVideoHeight,
+                ),
+            )
         }
 
         viewModel.playVideo(videoUrl = "http://somehost.com/someview.mp4")
@@ -88,34 +95,45 @@ internal class ExoPlayerViewModelTest {
 
         val errorMessages = viewModel.uiState.value.errorMessages
         assertEquals(1, errorMessages.size)
-        assertEquals("HTTP Error ${PlaybackExceptionSampleData.invalidResponseCodeExceptionErrorCode}", errorMessages[0].message)
+        assertEquals(
+            "HTTP Error ${PlaybackExceptionSampleData.invalidResponseCodeExceptionErrorCode}",
+            errorMessages[0].message,
+        )
     }
 
     @Test
-    fun `updates UI state with HttpDataSourceException message when player encounters HttpDataSourceException`() = runTest {
-        every { mockPlayer.play() } answers {
-            listenerSlot.captured.onPlayerError(PlaybackExceptionSampleData.httpDataSourceException)
+    fun `updates UI state with HttpDataSourceException message when player encounters HttpDataSourceException`() =
+        runTest {
+            every { mockPlayer.play() } answers {
+                listenerSlot.captured.onPlayerError(PlaybackExceptionSampleData.httpDataSourceException)
+            }
+
+            viewModel.playVideo(videoUrl = "http://somehost.com/someview.mp4")
+
+            val errorMessages = viewModel.uiState.value.errorMessages
+            assertEquals(1, errorMessages.size)
+            assertEquals(
+                PlaybackExceptionSampleData.httpDataSourceExceptionMessage,
+                errorMessages[0].message,
+            )
         }
-
-        viewModel.playVideo(videoUrl = "http://somehost.com/someview.mp4")
-
-        val errorMessages = viewModel.uiState.value.errorMessages
-        assertEquals(1, errorMessages.size)
-        assertEquals(PlaybackExceptionSampleData.httpDataSourceExceptionMessage, errorMessages[0].message)
-    }
 
     @Test
-    fun `updates UI state with generic exception message when player encounters generic exception`() = runTest {
-        every { mockPlayer.play() } answers {
-            listenerSlot.captured.onPlayerError(PlaybackExceptionSampleData.genericException)
+    fun `updates UI state with generic exception message when player encounters generic exception`() =
+        runTest {
+            every { mockPlayer.play() } answers {
+                listenerSlot.captured.onPlayerError(PlaybackExceptionSampleData.genericException)
+            }
+
+            viewModel.playVideo(videoUrl = "http://somehost.com/someview.mp4")
+
+            val errorMessages = viewModel.uiState.value.errorMessages
+            assertEquals(1, errorMessages.size)
+            assertEquals(
+                PlaybackExceptionSampleData.genericExceptionMessage,
+                errorMessages[0].message,
+            )
         }
-
-        viewModel.playVideo(videoUrl = "http://somehost.com/someview.mp4")
-
-        val errorMessages = viewModel.uiState.value.errorMessages
-        assertEquals(1, errorMessages.size)
-        assertEquals(PlaybackExceptionSampleData.genericExceptionMessage, errorMessages[0].message)
-    }
 
     @Test
     fun `returns the correct player instance`() {
@@ -169,8 +187,14 @@ internal class ExoPlayerViewModelTest {
 
         val uiState = viewModel.uiState.value
         assertEquals(2, uiState.errorMessages.size)
-        assertEquals(PlaybackExceptionSampleData.genericExceptionMessage, uiState.errorMessages[0].message)
-        assertEquals(PlaybackExceptionSampleData.ioExceptionMessage, uiState.errorMessages[1].message)
+        assertEquals(
+            PlaybackExceptionSampleData.genericExceptionMessage,
+            uiState.errorMessages[0].message,
+        )
+        assertEquals(
+            PlaybackExceptionSampleData.ioExceptionMessage,
+            uiState.errorMessages[1].message,
+        )
     }
 
     @Test
@@ -185,7 +209,10 @@ internal class ExoPlayerViewModelTest {
 
         val uiState = viewModel.uiState.value
         assertEquals(1, uiState.errorMessages.size)
-        assertEquals(PlaybackExceptionSampleData.genericExceptionMessage, uiState.errorMessages[0].message)
+        assertEquals(
+            PlaybackExceptionSampleData.genericExceptionMessage,
+            uiState.errorMessages[0].message,
+        )
     }
 
     @Test

--- a/app/src/test/java/com/rwmobi/dazncodechallenge/ui/destinations/schedule/ScheduleViewModelTest.kt
+++ b/app/src/test/java/com/rwmobi/dazncodechallenge/ui/destinations/schedule/ScheduleViewModelTest.kt
@@ -5,14 +5,10 @@
  *
  */
 
-package com.rwmobi.dazncodechallenge.ui.viewmodel
+package com.rwmobi.dazncodechallenge.ui.destinations.schedule
 
-import coil.ImageLoader
 import com.rwmobi.dazncodechallenge.data.repository.FakeRepository
-import com.rwmobi.dazncodechallenge.test.ScheduleSampleData.schedule1
-import com.rwmobi.dazncodechallenge.test.ScheduleSampleData.schedule2
-import com.rwmobi.dazncodechallenge.test.ScheduleSampleData.schedule3
-import io.mockk.mockk
+import com.rwmobi.dazncodechallenge.test.ScheduleSampleData
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Before
@@ -21,13 +17,11 @@ import java.io.IOException
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
-import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @ExperimentalCoroutinesApi
 internal class ScheduleViewModelTest {
     private lateinit var fakeRepository: FakeRepository
-    private lateinit var mockImageLoader: ImageLoader
 
     // Subject under test
     private lateinit var viewModel: ScheduleViewModel
@@ -35,10 +29,8 @@ internal class ScheduleViewModelTest {
     @Before
     fun init() {
         fakeRepository = FakeRepository()
-        mockImageLoader = mockk(relaxed = true)
         viewModel = ScheduleViewModel(
             repository = fakeRepository,
-            imageLoader = mockImageLoader,
             dispatcher = UnconfinedTestDispatcher(),
         )
     }
@@ -47,21 +39,34 @@ internal class ScheduleViewModelTest {
 
     @Test
     fun `displays refreshed schedules when fetchCacheAndRefresh is successful`() {
-        fakeRepository.setRemoteSchedulesForTest(listOf(schedule1, schedule2))
-        fakeRepository.setLocalSchedulesForTest(listOf(schedule3))
+        fakeRepository.setRemoteSchedulesForTest(
+            listOf(
+                ScheduleSampleData.schedule1,
+                ScheduleSampleData.schedule2,
+            ),
+        )
+        fakeRepository.setLocalSchedulesForTest(listOf(ScheduleSampleData.schedule3))
 
         viewModel.fetchCacheAndRefresh()
 
         val uiState = viewModel.uiState.value
         assertFalse(uiState.isLoading)
-        assertEquals(listOf(schedule1, schedule2), uiState.schedules)
+        assertEquals(
+            listOf(ScheduleSampleData.schedule1, ScheduleSampleData.schedule2),
+            uiState.schedules,
+        )
     }
 
     @Test
     fun `shows error when fetchCacheAndRefresh fails`() {
         val exceptionMessage = "repository error"
         fakeRepository.setExceptionForTest(IOException(exceptionMessage))
-        fakeRepository.setRemoteSchedulesForTest(listOf(schedule1, schedule2))
+        fakeRepository.setRemoteSchedulesForTest(
+            listOf(
+                ScheduleSampleData.schedule1,
+                ScheduleSampleData.schedule2,
+            ),
+        )
 
         viewModel.fetchCacheAndRefresh()
 
@@ -74,20 +79,28 @@ internal class ScheduleViewModelTest {
 
     @Test
     fun `updates schedules successfully when refresh is called`() {
-        fakeRepository.setRemoteSchedulesForTest(listOf(schedule1, schedule2))
-        fakeRepository.setLocalSchedulesForTest(listOf(schedule3))
+        fakeRepository.setRemoteSchedulesForTest(
+            listOf(
+                ScheduleSampleData.schedule1,
+                ScheduleSampleData.schedule2,
+            ),
+        )
+        fakeRepository.setLocalSchedulesForTest(listOf(ScheduleSampleData.schedule3))
         viewModel.fetchCacheAndRefresh()
 
         viewModel.refresh()
 
         val uiState = viewModel.uiState.value
         assertFalse(uiState.isLoading)
-        assertEquals(listOf(schedule1, schedule2), uiState.schedules)
+        assertEquals(
+            listOf(ScheduleSampleData.schedule1, ScheduleSampleData.schedule2),
+            uiState.schedules,
+        )
     }
 
     @Test
     fun `retains cached schedules and shows error when refresh fails`() {
-        fakeRepository.setRemoteSchedulesForTest(listOf(schedule3))
+        fakeRepository.setRemoteSchedulesForTest(listOf(ScheduleSampleData.schedule3))
         viewModel.fetchCacheAndRefresh()
 
         val exceptionMessage = "repository error"
@@ -96,7 +109,7 @@ internal class ScheduleViewModelTest {
 
         val uiState = viewModel.uiState.value
         assertFalse(uiState.isLoading)
-        assertEquals(listOf(schedule3), uiState.schedules)
+        assertEquals(listOf(ScheduleSampleData.schedule3), uiState.schedules)
         assertEquals(1, uiState.errorMessages.size)
         assertEquals(exceptionMessage, uiState.errorMessages[0].message)
     }
@@ -168,13 +181,5 @@ internal class ScheduleViewModelTest {
 
         val uiState = viewModel.uiState.value
         assertEquals(expectedRequestScrollToTop, uiState.requestScrollToTop)
-    }
-
-    @Test
-    fun `returns correct imageLoader instance when getImageLoader is called`() {
-        viewModel.fetchCacheAndRefresh()
-        val expectedImageLoader = mockImageLoader
-        val imageLoader = viewModel.getImageLoader()
-        assertSame(expectedImageLoader, imageLoader)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ buildToolsVersion = "35.0.0"
 activityCompose = "1.10.1"
 agp = "8.11.0"
 benchmarkMacroJunit4 = "1.3.4"
-coil = "2.7.0"
+coil = "3.2.0"
 composeBom = "2025.06.01"
 converterMoshi = "3.0.0"
 coroutines = "1.10.2"
@@ -90,8 +90,10 @@ moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
 
-coil = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
-coil-gif = { group = "io.coil-kt", name = "coil-gif", version.ref = "coil" }
+coil = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+coil-gif = { group = "io.coil-kt.coil3", name = "coil-gif", version.ref = "coil" }
+coil-network-ktor3 = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", version.ref = "coil" }
+coil-test = { group = "io.coil-kt.coil3", name = "coil-test", version.ref = "coil" }
 
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,8 +3,8 @@
 versionCode = "8"
 versionName = "2.3.0"
 minSdk = "28"
-targetSdk = "35"
-compileSdk = "35"
+targetSdk = "36"
+compileSdk = "36"
 buildToolsVersion = "35.0.0"
 
 activityCompose = "1.10.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,7 +92,7 @@ timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "tim
 
 coil = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-gif = { group = "io.coil-kt.coil3", name = "coil-gif", version.ref = "coil" }
-coil-network-ktor3 = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", version.ref = "coil" }
+coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
 coil-test = { group = "io.coil-kt.coil3", name = "coil-test", version.ref = "coil" }
 
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }


### PR DESCRIPTION
Reviewed by Gemini and ChatGPT, we have identified the root cause of the issue, which originated from our injection of ImageLoader via the viewmodel - it was done for Exoplayer.

Exoplayer's use case is valid, but not for ImageLoader, so we now change to inject it from the Activity.