### PR TITLE
Implement left and right sliding interface to switch pages

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-07-05T23:48:56.537938Z">
+        <DropdownSelection timestamp="2025-10-14T06:47:39.339749Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="PhysicalDevice" identifier="serial=276a64acda217ece" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=/Users/admin/.android/avd/Pixel_9_Pro.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,6 +97,10 @@ kotlin {
 }
 
 dependencies {
+    // Accompanist Pager
+    implementation(libs.google.accompanist.pager)
+    implementation(libs.google.accompanist.pager.indicators)
+
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.core.ktx)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+accompanist = "0.32.0"
 activityCompose = "1.11.0"
 agp = "8.13.0"
 benchmarkMacroJunit4 = "1.4.1"
@@ -114,6 +115,9 @@ leakcanary-android = { group = "com.squareup.leakcanary", name = "leakcanary-and
 androidx-material3-adaptive-android = { group = "androidx.compose.material3", name = "material3-adaptive-android", version.ref = "material3AdaptiveAndroid" }
 androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
+
+google-accompanist-pager = { group = "com.google.accompanist", name = "accompanist-pager", version.ref = "accompanist" }
+google-accompanist-pager-indicators = { group = "com.google.accompanist", name = "accompanist-pager-indicators", version.ref = "accompanist" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Functionality:
Added left-right swipe functionality to the navigation bar, adapting to two navigation styles:
1. Side Navigation: Swipe the main content area to switch pages, and the navigation selection status will be updated simultaneously.
2. Bottom Navigation: Swipe to switch between pages, just like tapping a navigation item.
3. Swipe is disabled in PIP mode to avoid interaction conflicts.

## Implementation method:
- Use Jetpack Compose's HorizontalPager to manage page scrolling.
- Monitor pager state changes and synchronously update the NavController navigation state.
- When a navigation item is clicked, the pager animation switches to the corresponding page.

## Test situation:
- We've tested both tablet (side navigation) and phone (bottom navigation) scenarios, and swiping works correctly.
- We've tested PIP mode, and swiping works correctly.

## Effect:
[Screen_recording_20251014_142721.webm](https://github.com/user-attachments/assets/9c9cbf5c-333a-441f-bc87-324c848dc1bf)

