### PR TITLE
[style] ExoPlayerScreen: move comment out from when() to resolve lint error

### DIFF
--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerScreen.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/destinations/exoplayer/ExoPlayerScreen.kt
@@ -133,11 +133,11 @@ fun ExoPlayerScreen(
                 }
             },
             update = { playerView ->
+                /**
+                 * In Android 7.0 and later, you should pause and resume video playback when the system calls your activity's onStop() and onStart().
+                 * By doing this, you can avoid having to check if your app is in PiP mode in onPause() and explicitly continuing playback.
+                 */
                 when (lifecycle) {
-                    /**
-                     * In Android 7.0 and later, you should pause and resume video playback when the system calls your activity's onStop() and onStart().
-                     * By doing this, you can avoid having to check if your app is in PiP mode in onPause() and explicitly continuing playback.
-                     */
                     Lifecycle.Event.ON_PAUSE -> {
                         playerView.hideController()
                     }


### PR DESCRIPTION
Lint rule being more strict and we have to correct this for a successful build.