### PR TITLE
App: fix Gradle to work with AGP 9.0

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -22,18 +22,18 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: set up JDK 17
+      - name: set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '17'
+          java-version: '21'
           cache: gradle
 
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
 
       - name: Gradle build
-        run: ./gradlew :app:buildReleasePreBundle :app:koverXmlReportRelease
+        run: ./gradlew :app:buildReleasePreBundle :app:koverXmlReportDebug
         env:
           CI: 'true'
           KEYSTORE_LOCATION: ${{ steps.decode_keystore.outputs.filePath }}
@@ -45,4 +45,4 @@ jobs:
         uses: codacy/codacy-coverage-reporter-action@v1.3.0
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: app/build/reports/kover/reportRelease.xml
+          coverage-reports: app/build/reports/kover/reportDebug.xml

--- a/.github/workflows/renovate_check.yml
+++ b/.github/workflows/renovate_check.yml
@@ -20,11 +20,11 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: set up JDK 17
+      - name: set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '17'
+          java-version: '21'
           cache: gradle
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/tag_create_release.yml
+++ b/.github/workflows/tag_create_release.yml
@@ -19,11 +19,11 @@ jobs:
 
       - uses: actions/checkout@v6
 
-      - name: set up JDK 17
+      - name: set up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '17'
+          java-version: '21'
           cache: gradle
 
       - name: Grant execute permission for gradlew

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17">
+    <bytecodeTargetLevel target="21">
       <module name="DAZN_Code_Challenge.baselineprofile" target="21" />
     </bytecodeTargetLevel>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ This applies to both APK and AAB artifacts.
 The `.github/workflows/tag_create_release.yml` file defines the CI/CD pipeline. It performs the following:
 
 1. Checks out the code.
-2. Sets up JDK 17.
+2. Sets up JDK 21.
 3. Builds the APK and AAB using Gradle.
 4. Creates a GitHub Release.
 5. Uploads the outputs as release assets.

--- a/app/src/testFixtures/java/com/rwmobi/dazncodechallenge/test/PlaybackExceptionSampleData.kt
+++ b/app/src/testFixtures/java/com/rwmobi/dazncodechallenge/test/PlaybackExceptionSampleData.kt
@@ -15,6 +15,8 @@ import java.io.IOException
 
 object PlaybackExceptionSampleData {
     val invalidResponseCodeExceptionErrorCode = 403
+
+    @androidx.media3.common.util.UnstableApi
     val invalidResponseCodeException = PlaybackException(
         "Connection Failed",
         HttpDataSource.InvalidResponseCodeException(
@@ -29,6 +31,8 @@ object PlaybackExceptionSampleData {
     )
 
     val httpDataSourceExceptionMessage = "Some IO Exception"
+
+    @androidx.media3.common.util.UnstableApi
     val httpDataSourceException = PlaybackException(
         "Connection Failed",
         HttpDataSource.HttpDataSourceException(
@@ -42,6 +46,8 @@ object PlaybackExceptionSampleData {
     )
 
     val genericExceptionMessage = "Some generic exception"
+
+    @androidx.media3.common.util.UnstableApi
     val genericException = PlaybackException(
         "Connection Failed",
         Exception(genericExceptionMessage),
@@ -49,6 +55,8 @@ object PlaybackExceptionSampleData {
     )
 
     val ioExceptionMessage = "Some IO exception"
+
+    @androidx.media3.common.util.UnstableApi
     val ioException = PlaybackException(
         "Connection Failed",
         Exception(ioExceptionMessage),

--- a/baselineprofile/build.gradle.kts
+++ b/baselineprofile/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.androidTest)
-    alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.baselineprofile)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.androidApplication) apply false
-    alias(libs.plugins.jetbrainsKotlinAndroid) apply false
     alias(libs.plugins.hiltAndroidPlugin) apply false
     alias(libs.plugins.devtoolsKsp) apply false
     alias(libs.plugins.kotlinxKover) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activityCompose = "1.12.3"
-agp = "8.13.2"
+agp = "9.0.0"
 benchmarkMacroJunit4 = "1.4.1"
 coil = "3.3.0"
 composeBom = "2026.01.01"
@@ -11,7 +11,7 @@ coreSplashscreen = "1.2.0"
 datastoreVersion = "1.2.0"
 devtoolsksp = "2.3.5"
 espressoCore = "3.7.0"
-hilt = "2.58"
+hilt = "2.59.1"
 hiltNavigationCompose = "1.3.0"
 jetbrainsKotlinxCoroutinesTest = "1.10.2"
 junit = "4.13.2"
@@ -35,11 +35,12 @@ testRules = "1.7.0"
 timber = "5.0.1"
 material3AdaptiveAndroid = "1.0.0-alpha06"
 uiautomator = "2.3.0"
-baselineprofile = "1.4.1"
+baselineprofile = "1.5.0-alpha02"
 profileinstaller = "1.4.1"
 media3Exoplayer = "1.9.2"
 kotlinter = "5.4.0"
 detekt = "1.23.8"
+kotlinTestJunit = "2.3.10"
 
 # App configurations, not dependencies
 minSdk = "28"
@@ -114,10 +115,10 @@ leakcanary-android = { group = "com.squareup.leakcanary", name = "leakcanary-and
 androidx-material3-adaptive-android = { group = "androidx.compose.material3", name = "material3-adaptive-android", version.ref = "material3AdaptiveAndroid" }
 androidx-uiautomator = { group = "androidx.test.uiautomator", name = "uiautomator", version.ref = "uiautomator" }
 androidx-profileinstaller = { group = "androidx.profileinstaller", name = "profileinstaller", version.ref = "profileinstaller" }
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlinTestJunit" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
-jetbrainsKotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 hiltAndroidPlugin = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinxKover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }


### PR DESCRIPTION
# PR Description: Upgrade to JDK 21 and AGP 9.0

This pull request updates the project's core build infrastructure to **JDK 21** and **Android Gradle Plugin (AGP) 9.0.0**, along with significant refactoring of the build logic and dependency updates.

## Key Changes

### 🛠 Build System & Tooling
*   **JDK 21 Migration**:
    *   Updated `jvmToolchain` and compiler compatibility options to JDK 21.
    *   Updated IDE configuration files (`.idea/compiler.xml`, `.idea/misc.xml`) to use JDK 21.
    *   Synchronized all GitHub Actions workflows to run on JDK 21.
*   **AGP 9.0 Upgrade**: Lifted the Android Gradle Plugin version from `8.13.2` to `9.0.0`.
*   **Refactored `app/build.gradle.kts`**:
    *   Migrated from internal `BaseAppModuleExtension` to the public `ApplicationExtension` API.
    *   **Conditional Signing**: Added a `releaseSigning` Gradle property check. Release builds now only attempt to load keystores if `-PreleaseSigning=true` is provided, preventing build failures in environments without secrets.
    *   **New `benchmark` Build Type**: Added a specific build type for macrobenchmark testing, initialized from release but using debug signing.
    *   **Artifact Naming**: Streamlined APK naming using `archivesName` extension.
*   **CI Updates**: Changed the Kover coverage report task in CI to use the `debug` variant for faster feedback loops.

### 📦 Dependency Updates
*   **Hilt**: Upgraded to `2.59.1`.
*   **Baseline Profile**: Upgraded to `1.5.0-alpha02`.
*   **Testing**:
    *   Added `kotlin-test-junit` to `test` and `androidTest` configurations.
    *   Expanded `testFixtures` dependencies to include Compose and Media3 test utilities.

### 📝 Code & Documentation
*   **Media3 Unstable API**: Added `@UnstableApi` annotations to `PlaybackException` helpers in `testFixtures` to satisfy compiler requirements.
*   **README**: Updated the documentation to reflect the move to JDK 21.
*   **Cleanup**: Removed redundant Kotlin plugin applications in subprojects.

## How to Test
1.  **Gradle Sync**: Verify that the project syncs successfully with JDK 21 in Android Studio.
2.  **Assemble**: Run `./gradlew assembleDebug` to ensure the app builds correctly.
3.  **Run Tests**: Execute `./gradlew test` to verify that the updated dependencies and JDK version haven't introduced regressions.
4.  **CI Validation**: Check the GitHub Actions run for this PR to ensure build and coverage steps pass.