### PR TITLE
Fix broken API and status bar visibility in edge-to-edge mode

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -32,6 +32,9 @@ The project uses Gradle with the Kotlin DSL and Version Catalog.
 *   **Run Unit Tests:**
     ```bash
     ./gradlew test
+    # Run a single test class or method:
+    ./gradlew test --tests "com.rwmobi.dazncodechallenge.data.repository.LocalCacheRepositoryTest"
+    ./gradlew test --tests "com.rwmobi.dazncodechallenge.data.repository.LocalCacheRepositoryTest.refreshEvents*"
     ```
 *   **Run Instrumented Tests:**
     ```bash
@@ -66,6 +69,42 @@ The project uses Gradle with the Kotlin DSL and Version Catalog.
     *   UI tests should use the Robot pattern for better maintainability (see `MainActivityTestRobot.kt`).
 *   **Coding Style:** Follow the project's formatting rules (enforced by `kotlinter` and `detekt`).
 *   **Version Management:** All dependency versions are managed in `gradle/libs.versions.toml`.
+
+## Architecture Details
+
+### Cache Synchronization (Dirty Bit Pattern)
+
+`RoomDbDataSource` replaces the cache atomically in three steps rather than delete-and-insert:
+1. Mark all existing rows `dirty = true`
+2. `insertAll()` with `REPLACE` conflict strategy (new rows arrive with `dirty = false`)
+3. Delete remaining rows where `dirty = true`
+
+This safely handles full-dataset API responses. The repository separates reads from refreshes — `get*()` always reads local DB only; `refresh*()` fetches from network and writes to local DB.
+
+### UIEvent Function Interfaces
+
+Screens do not call ViewModels directly. Each destination defines a `*UIEvent` data class of lambdas that is constructed in the navigation graph and passed into the screen composable. This decouples screens from ViewModel types and simplifies Compose Previews.
+
+### Adaptive Layout
+
+`DAZNCodeChallengeApp` maps `WindowWidthSizeClass` to an internal `NavigationLayoutType` enum:
+- `COMPACT` → `BOTTOM_NAVIGATION`
+- `MEDIUM` / `EXPANDED` → `NAVIGATION_RAIL`
+- ExoPlayer route **or** PiP active → `FULL_SCREEN` (no navigation chrome)
+
+The ExoPlayer destination is not listed in the navigation bar entries (`AppNavItem`); it is reached via `"exoplayer/{videoUrl}"` with a URL-encoded path parameter.
+
+### Error Message Queue
+
+ViewModels hold a `List<ErrorMessage>` in UI state, each entry keyed by a `UUID`. Calling `onErrorShown(id)` filters that ID from the list, preventing duplicate Snackbars and allowing per-error dismissal.
+
+### Testing: testFixtures
+
+Shared test data lives in `app/src/testFixtures/` and provides domain model instances, DB entity instances, network DTO instances, and fake implementations (`FakeRepository`, `FakeLocalDataSource`, `FakeRemoteDataSource`). Inject `UnconfinedTestDispatcher()` in place of the real IO dispatcher for synchronous coroutine execution in unit tests.
+
+### Code Quality Gate
+
+Detekt is configured with `maxIssues: 0` in `config/detekt/detekt.yml` — any new violation fails the build. Notable non-default thresholds: `LongMethod` is 120 lines but excludes `@Composable` functions; `LongParameterList` ignores `@Composable` and data class constructors.
 
 ## Key Files
 

--- a/app/src/main/assets/getEvents.json
+++ b/app/src/main/assets/getEvents.json
@@ -1,0 +1,130 @@
+[
+  {
+    "id": 1,
+    "title": "Liverpool v Porto",
+    "subtitle": "UEFA Champions League",
+    "date": "2024-04-22T01:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310176837169_image-header_pDach_1554579780000.jpeg?alt=media&token=1777d26b-d051-4b5f-87a8-7633d3d6dd20",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 2,
+    "title": "Nîmes v Rennes",
+    "subtitle": "Ligue 1",
+    "date": "2024-04-22T02:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310381637057_image-header_pDach_1554664873000.jpeg?alt=media&token=53616931-55a8-476e-b1b7-d18fc22a2bf0",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 3,
+    "title": "Tottenham v Man City",
+    "subtitle": "UEFA Champions League",
+    "date": "2024-04-22T03:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310511685198_image-header_pDach_1554872450000.jpeg?alt=media&token=5524d719-261e-49e6-abf3-a74c30df3e27",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 4,
+    "title": "Suns @ Mavericks",
+    "subtitle": "NBA",
+    "date": "2024-04-22T04:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310572613233_image-header_pDach_1554812508000.jpeg?alt=media&token=4ee99b47-dcae-4016-b213-54e14a0d40d8",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 5,
+    "title": "Chelsea v West Ham",
+    "subtitle": "Premier League",
+    "date": "2024-04-22T05:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310632005268_image-header_pDach_1554838415000.jpeg?alt=media&token=5a512da9-d268-432c-9da2-088c8e6737e1",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 6,
+    "title": "Hamburger SV v 1. FC Magdeburg",
+    "subtitle": "2. Bundesliga",
+    "date": "2024-04-22T06:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310638661042_image-header_pDach_1554833728000.jpeg?alt=media&token=0415f88e-8d07-4b95-b5d6-4ee3efaa8e5c",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 7,
+    "title": "Virginia v Texas Tech",
+    "subtitle": "NCAA College Basketball",
+    "date": "2024-04-22T08:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310667845502_image-header_pDach_1554723738000.jpeg?alt=media&token=8c09ca4a-867c-4a26-9e56-463523808fa5",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 8,
+    "title": "Dodgers @ Cardinals",
+    "subtitle": "MLB Baseball",
+    "date": "2024-04-22T09:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310798917361_image-header_pDach_1554667420000.jpeg?alt=media&token=7c15b201-0842-4aaf-acb4-6bd2c6a5bb4d",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 9,
+    "title": "Interview Sadio Mane",
+    "subtitle": "#DAZNbreakfast",
+    "date": "2024-04-22T10:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/311013957255_image-header_pDach_1554750958000.jpeg?alt=media&token=5bf9b5fd-52c1-4c54-8f7d-4671d9385f5c",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 10,
+    "title": "Pre-Match ITV: Jürgen Klopp",
+    "subtitle": "",
+    "date": "2024-04-22T10:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/311354437259_image-header_pDach_1554838977000.jpeg?alt=media&token=8135fc30-3340-4449-9b45-daa9adc1bbc9",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 11,
+    "title": "CSKA Moskow v St Petersburg",
+    "subtitle": "KHL Ice Hockey",
+    "date": "2024-04-22T10:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/311428677455_image-header_pDach_1554829417000.jpeg?alt=media&token=ea122c47-2a50-4cf2-a901-2be2ff94f3c4",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 12,
+    "title": "Rockets @ Thunder",
+    "subtitle": "NBA",
+    "date": "2024-04-22T10:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/311471173073_image-header_pDach_1554571998000.jpeg?alt=media&token=a69da8e4-d2d1-45f0-a005-977311981d66",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 13,
+    "title": "PSG v Strasbourg",
+    "subtitle": "Ligue 1",
+    "date": "2024-04-22T10:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/311953989300_image-header_pDach_1554750608000.jpeg?alt=media&token=56f3a7a8-2f10-436c-8069-c762b37594cd",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 14,
+    "title": "Barcelona v Atlético Madrid",
+    "subtitle": "La Liga",
+    "date": "2024-04-22T10:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/313767493498_image-header_pDach_1554718914000.jpeg?alt=media&token=77861419-1012-4b1d-ab36-04c53488aee9",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 15,
+    "title": "Career of a legend",
+    "subtitle": "Documentary",
+    "date": "2024-04-22T10:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/314428485312_image-header_pDach_1554414738000.jpeg?alt=media&token=60571ae8-9fb0-4724-9b41-ce9f7bf36334",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  },
+  {
+    "id": 16,
+    "title": "Mavericks @ Grizzlies",
+    "subtitle": "NBA",
+    "date": "2024-04-22T10:27:28.136Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/314686021006_image-header_pDach_1554739950000.jpeg?alt=media&token=bf82b1da-e965-44f5-ac08-2170b4625566",
+    "videoUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/promo.mp4?alt=media"
+  }
+]

--- a/app/src/main/assets/getSchedule.json
+++ b/app/src/main/assets/getSchedule.json
@@ -1,0 +1,114 @@
+[
+  {
+    "id": 1,
+    "title": "Liverpool v Porto",
+    "subtitle": "UEFA Champions League",
+    "date": "2024-04-23T06:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310176837169_image-header_pDach_1554579780000.jpeg?alt=media&token=1777d26b-d051-4b5f-87a8-7633d3d6dd20"
+  },
+  {
+    "id": 2,
+    "title": "Nîmes v Rennes",
+    "subtitle": "Ligue 1",
+    "date": "2024-04-23T04:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310381637057_image-header_pDach_1554664873000.jpeg?alt=media&token=53616931-55a8-476e-b1b7-d18fc22a2bf0"
+  },
+  {
+    "id": 3,
+    "title": "Tottenham v Man City",
+    "subtitle": "UEFA Champions League",
+    "date": "2024-04-23T08:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310511685198_image-header_pDach_1554872450000.jpeg?alt=media&token=5524d719-261e-49e6-abf3-a74c30df3e27"
+  },
+  {
+    "id": 4,
+    "title": "Suns @ Mavericks",
+    "subtitle": "NBA",
+    "date": "2024-04-23T09:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310572613233_image-header_pDach_1554812508000.jpeg?alt=media&token=4ee99b47-dcae-4016-b213-54e14a0d40d8"
+  },
+  {
+    "id": 5,
+    "title": "Chelsea v West Ham",
+    "subtitle": "Premier League",
+    "date": "2024-04-23T10:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310632005268_image-header_pDach_1554838415000.jpeg?alt=media&token=5a512da9-d268-432c-9da2-088c8e6737e1"
+  },
+  {
+    "id": 6,
+    "title": "Hamburger SV v 1. FC Magdeburg",
+    "subtitle": "2. Bundesliga",
+    "date": "2024-04-23T11:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310638661042_image-header_pDach_1554833728000.jpeg?alt=media&token=0415f88e-8d07-4b95-b5d6-4ee3efaa8e5c"
+  },
+  {
+    "id": 7,
+    "title": "Virginia v Texas Tech",
+    "subtitle": "NCAA College Basketball",
+    "date": "2024-04-23T13:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310667845502_image-header_pDach_1554723738000.jpeg?alt=media&token=8c09ca4a-867c-4a26-9e56-463523808fa5"
+  },
+  {
+    "id": 8,
+    "title": "Dodgers @ Cardinals",
+    "subtitle": "MLB Baseball",
+    "date": "2024-04-23T14:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/310798917361_image-header_pDach_1554667420000.jpeg?alt=media&token=7c15b201-0842-4aaf-acb4-6bd2c6a5bb4d"
+  },
+  {
+    "id": 9,
+    "title": "Interview Sadio Mane",
+    "subtitle": "#DAZNbreakfast",
+    "date": "2024-04-23T15:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/311013957255_image-header_pDach_1554750958000.jpeg?alt=media&token=5bf9b5fd-52c1-4c54-8f7d-4671d9385f5c"
+  },
+  {
+    "id": 10,
+    "title": "Pre-Match ITV: Jürgen Klopp",
+    "subtitle": "",
+    "date": "2024-04-23T15:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/311354437259_image-header_pDach_1554838977000.jpeg?alt=media&token=8135fc30-3340-4449-9b45-daa9adc1bbc9"
+  },
+  {
+    "id": 11,
+    "title": "CSKA Moskow v St Petersburg",
+    "subtitle": "KHL Ice Hockey",
+    "date": "2024-04-23T15:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/311428677455_image-header_pDach_1554829417000.jpeg?alt=media&token=ea122c47-2a50-4cf2-a901-2be2ff94f3c4"
+  },
+  {
+    "id": 12,
+    "title": "Rockets @ Thunder",
+    "subtitle": "NBA",
+    "date": "2024-04-23T15:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/311471173073_image-header_pDach_1554571998000.jpeg?alt=media&token=a69da8e4-d2d1-45f0-a005-977311981d66"
+  },
+  {
+    "id": 13,
+    "title": "PSG v Strasbourg",
+    "subtitle": "Ligue 1",
+    "date": "2024-04-23T15:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/311953989300_image-header_pDach_1554750608000.jpeg?alt=media&token=56f3a7a8-2f10-436c-8069-c762b37594cd"
+  },
+  {
+    "id": 14,
+    "title": "Barcelona v Atlético Madrid",
+    "subtitle": "La Liga",
+    "date": "2024-04-23T15:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/313767493498_image-header_pDach_1554718914000.jpeg?alt=media&token=77861419-1012-4b1d-ab36-04c53488aee9"
+  },
+  {
+    "id": 15,
+    "title": "Career of a legend",
+    "subtitle": "Documentary",
+    "date": "2024-04-23T04:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/314428485312_image-header_pDach_1554414738000.jpeg?alt=media&token=60571ae8-9fb0-4724-9b41-ce9f7bf36334"
+  },
+  {
+    "id": 16,
+    "title": "Mavericks @ Grizzlies",
+    "subtitle": "NBA",
+    "date": "2024-04-23T04:28:14.604Z",
+    "imageUrl": "https://firebasestorage.googleapis.com/v0/b/dazn-recruitment/o/314686021006_image-header_pDach_1554739950000.jpeg?alt=media&token=bf82b1da-e965-44f5-ac08-2170b4625566"
+  }
+]

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/MainActivity.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/MainActivity.kt
@@ -16,7 +16,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.safeContentPadding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
@@ -50,20 +49,19 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(
+                scrim = Color.Transparent.toArgb(),
+            ),
+            navigationBarStyle = SystemBarStyle.dark(
+                scrim = Color.Transparent.toArgb(),
+            ),
+        )
 
         super.onCreate(savedInstanceState)
         setContent {
             val navController = rememberNavController()
             val snackbarHostState = remember { SnackbarHostState() }
-
-            enableEdgeToEdge(
-                statusBarStyle = SystemBarStyle.dark(
-                    scrim = Color.Transparent.toArgb(),
-                ),
-                navigationBarStyle = SystemBarStyle.dark(
-                    scrim = Color.Transparent.toArgb(),
-                ),
-            )
 
             VideoPlayerAppTheme {
                 Surface(

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/data/source/network/AssetFileDataSource.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/data/source/network/AssetFileDataSource.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.dazncodechallenge.data.source.network
+
+import android.content.Context
+import com.rwmobi.dazncodechallenge.data.source.network.dto.EventNetworkDto
+import com.rwmobi.dazncodechallenge.data.source.network.dto.ScheduleNetworkDto
+import com.rwmobi.dazncodechallenge.data.source.network.interfaces.NetworkDataSource
+import com.rwmobi.dazncodechallenge.di.DispatcherModule
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+class AssetFileDataSource @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val moshi: Moshi,
+    @DispatcherModule.IoDispatcher private val dispatcher: CoroutineDispatcher,
+) : NetworkDataSource {
+
+    override suspend fun getEvents(): List<EventNetworkDto> = withContext(dispatcher) {
+        val json = context.assets.open("getEvents.json").bufferedReader().use { it.readText() }
+        val type = Types.newParameterizedType(List::class.java, EventNetworkDto::class.java)
+        moshi.adapter<List<EventNetworkDto>>(type).fromJson(json) ?: emptyList()
+    }
+
+    override suspend fun getSchedules(): List<ScheduleNetworkDto> = withContext(dispatcher) {
+        val json = context.assets.open("getSchedule.json").bufferedReader().use { it.readText() }
+        val type = Types.newParameterizedType(List::class.java, ScheduleNetworkDto::class.java)
+        moshi.adapter<List<ScheduleNetworkDto>>(type).fromJson(json) ?: emptyList()
+    }
+}

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/di/DataSourceModule.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/di/DataSourceModule.kt
@@ -7,15 +7,17 @@
 
 package com.rwmobi.dazncodechallenge.di
 
+import android.content.Context
 import com.rwmobi.dazncodechallenge.data.source.local.DaznApiDatabase
 import com.rwmobi.dazncodechallenge.data.source.local.RoomDbDataSource
 import com.rwmobi.dazncodechallenge.data.source.local.interfaces.LocalDataSource
-import com.rwmobi.dazncodechallenge.data.source.network.DaznApiService
-import com.rwmobi.dazncodechallenge.data.source.network.SandBoxAPIDataSource
+import com.rwmobi.dazncodechallenge.data.source.network.AssetFileDataSource
 import com.rwmobi.dazncodechallenge.data.source.network.interfaces.NetworkDataSource
+import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.CoroutineDispatcher
 import javax.inject.Singleton
@@ -37,10 +39,12 @@ object DataSourceModule {
     @Provides
     @Singleton
     fun provideNetworkDataSource(
-        retrofitService: DaznApiService,
+        @ApplicationContext context: Context,
+        moshi: Moshi,
         @DispatcherModule.IoDispatcher dispatcher: CoroutineDispatcher,
-    ): NetworkDataSource = SandBoxAPIDataSource(
-        retrofitService = retrofitService,
+    ): NetworkDataSource = AssetFileDataSource(
+        context = context,
+        moshi = moshi,
         dispatcher = dispatcher,
     )
 }

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/components/EventListItem.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/components/EventListItem.kt
@@ -26,9 +26,9 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/components/ScheduleListItem.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/components/ScheduleListItem.kt
@@ -25,9 +25,9 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
 import coil3.ImageLoader
 import coil3.compose.AsyncImage
 import coil3.request.ImageRequest

--- a/app/src/main/java/com/rwmobi/dazncodechallenge/ui/theme/Theme.kt
+++ b/app/src/main/java/com/rwmobi/dazncodechallenge/ui/theme/Theme.kt
@@ -7,8 +7,6 @@
 
 package com.rwmobi.dazncodechallenge.ui.theme
 
-import android.app.Activity
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Shapes
@@ -16,15 +14,11 @@ import androidx.compose.material3.Typography
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.dp
-import androidx.core.view.WindowCompat
 
 private val UniversalColors = lightColorScheme(
     primary = md_theme_light_primary,
@@ -60,7 +54,6 @@ private val UniversalColors = lightColorScheme(
 
 @Composable
 fun VideoPlayerAppTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
     // Dynamic color is available on Android 12+, but this app we won't use it
     // dynamicColor: Boolean = false,
     content: @Composable () -> Unit,
@@ -70,14 +63,6 @@ fun VideoPlayerAppTheme(
     val dimension = if (containerSize.width <= with(density) { 360.dp.toPx() }) smallDimension else sw360Dimension
 
     val colorScheme = UniversalColors // This app has a fixed color theme
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
-        }
-    }
 
     ProvideDimens(dimensions = dimension) {
         MaterialTheme(


### PR DESCRIPTION
## Summary
- Replace broken remote sandbox API with `AssetFileDataSource` that reads bundled `getEvents.json` and `getSchedule.json` from Android assets, parsed via the existing Moshi instance — no Retrofit changes required
- Fix asset JSON files to use integer `id` values (were strings, mismatching `EventNetworkDto`/`ScheduleNetworkDto` which expect `Int`)
- Move `enableEdgeToEdge()` before `super.onCreate()` in `MainActivity` — was incorrectly called inside `setContent {}`, causing it to be overridden by the theme's `SideEffect` on every recomposition
- Remove conflicting `SideEffect` from `Theme.kt` that set `isAppearanceLightStatusBars = darkTheme` (backwards logic — produced black/invisible icons on a dark status bar) and explicitly set `window.statusBarColor`, both of which fought against `enableEdgeToEdge`

## Test plan
- [ ] App launches and displays event and schedule lists from the bundled JSON
- [ ] Status bar icons (time, battery, etc.) are visible (white) against the dark status bar
- [ ] Edge-to-edge layout is correct — content respects safe drawing insets
- [ ] No regression in PiP mode or navigation rail layout on larger screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)